### PR TITLE
feat: add wave listening visualization demo

### DIFF
--- a/examples/mic-waveform/demo.js
+++ b/examples/mic-waveform/demo.js
@@ -1,0 +1,51 @@
+const micBtn = document.getElementById('micBtn');
+const wave = document.getElementById('wave');
+const status = document.getElementById('status');
+
+const barCount = 12;
+let isListening = false;
+let animFrame = null;
+
+// Create bars
+wave.innerHTML = '';
+const bars = [];
+for (let i = 0; i < barCount; i++) {
+  const bar = document.createElement('div');
+  bar.className = 'bar';
+  wave.appendChild(bar);
+  bars.push(bar);
+}
+
+// Animation loop
+function animateWave() {
+  if (!isListening) {
+    bars.forEach(bar => bar.style.height = '10px');
+    return;
+  }
+  const t = Date.now() / 300;
+  bars.forEach((bar, i) => {
+    const scale = 10 + 28 * Math.abs(Math.sin(t + i * 0.4));
+    bar.style.height = `${scale}px`;
+  });
+  animFrame = requestAnimationFrame(animateWave);
+}
+
+// Start/stop animation and update opacity for visual feedback
+function setListening(listen) {
+  isListening = listen;
+  if (listen) {
+    wave.style.opacity = '1';
+    status.textContent = 'Listening...';
+    animFrame = requestAnimationFrame(animateWave);
+  } else {
+    wave.style.opacity = '0.4';
+    status.textContent = 'Mic is idle. Click to listen.';
+    cancelAnimationFrame(animFrame);
+    animateWave(); // reset bars
+  }
+}
+
+// Toggle listening state on button click
+micBtn.addEventListener('click', () => {
+  setListening(!isListening);
+});

--- a/examples/mic-waveform/index.html
+++ b/examples/mic-waveform/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <title>JSVoice Demo — Waveform Visual</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        body {
+            font-family: ui-sans-serif, system-ui;
+            padding: 24px;
+            background: #f7f7fb;
+        }
+
+        button {
+            font-size: 16px;
+            padding: 8px 12px;
+        }
+
+        #status {
+            margin-top: 12px;
+        }
+
+        #wave {
+            height: 40px;
+            display: flex;
+            gap: 4px;
+            align-items: flex-end;
+            margin-top: 24px;
+            transition: opacity 0.3s;
+            opacity: 0.4;
+        }
+
+        .bar {
+            width: 8px;
+            height: 10px;
+            background: #09f;
+            border-radius: 4px;
+            transition: height 0.15s;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>JSVoice — Waveform Visual Demo</h1>
+    <button id="micBtn">🎤</button>
+    <p id="status">Click Mic to toggle listening.</p>
+    <div id="wave"></div>
+    <!-- You can load JSVoice here if you want to integrate; for now, this is a visual demo only -->
+    <script src="./demo.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
### What does this PR do?

This PR adds a new demo in `examples/mic-waveform/` that visualizes microphone listening state using an animated sine wave.

- The demo uses a `<div id="wave">` element to display a smoothly animated sine wave when "listening" is active.
- When the mic is idle, the wave animation stops and fades to indicate inactivity.
- Clicking the mic button toggles the listening state and the animation.
- No real audio input is processed; animation is purely visual, as a placeholder for active listening.


https://github.com/user-attachments/assets/30092837-e4bd-49d0-b59d-772b7fe7f0e6


