### PR TITLE
Add OpenTabAction for opening new tab via voice

### DIFF
--- a/src/modules/BuiltInActions.js
+++ b/src/modules/BuiltInActions.js
@@ -20,8 +20,10 @@ import { handleDarkMode } from './actions/ToggleDarkModeAction.js';
  * @returns {boolean} True if a built-in action was handled, false otherwise.
  */
 export function handleBuiltInActions(rawTranscript, cleanedTranscript, updateStatus, callCallback, jsVoiceSpeakMethod) {
-  // Order defines priority. Read content is placed high due to its common use.
+  // Order defines priority. Open Tab and Read content is placed high due to its common use.
   // Pass rawTranscript here, as some actions (like FillInput or ReadContent) might need it for exact phrasing.
+
+  if (OpenTabAction(rawTranscript, cleanedTranscript, updateStatus, callCallback)) return true; 
   if (handleReadContent(rawTranscript, cleanedTranscript, updateStatus, callCallback, jsVoiceSpeakMethod)) return true;
   if (handleScroll(cleanedTranscript, updateStatus, callCallback)) return true;
   if (handleZoom(cleanedTranscript, updateStatus, callCallback)) return true;

--- a/src/modules/actions/OpenTabAction.js
+++ b/src/modules/actions/OpenTabAction.js
@@ -1,0 +1,57 @@
+// src/modules/actions/OpenTabAction.js
+
+const DOMAIN_MAPPINGS = {
+  google: "https://google.com",
+  github: "https://github.com",
+  youtube: "https://youtube.com",
+  facebook: "https://facebook.com",
+  twitter: "https://twitter.com",
+  linkedin: "https://linkedin.com",
+  chatGPT: "https://chat.openai.com",
+};
+
+function getUrlFromSite(site) {
+  site = site.toLowerCase().trim();
+  if (DOMAIN_MAPPINGS[site]) {
+    return DOMAIN_MAPPINGS[site];
+  }
+  return `https://${site}.com`;
+}
+
+/**
+ * Handles voice commands to open a new browser tab.
+ * @param {string} rawTranscript - The original recognized speech.
+ * @param {string} cleanedTranscript - The processed, cleaned speech.
+ * @param {Function} updateStatus - Status update function.
+ * @param {Function} callCallback - Callback function.
+ * @returns {boolean} True if handled, false otherwise.
+ */
+export function OpenTabAction(rawTranscript, cleanedTranscript, updateStatus, callCallback) {
+  const phrase = cleanedTranscript.toLowerCase().trim();
+
+  if (phrase === "open new tab") {
+    window.open("about:blank", "_blank");
+    updateStatus && updateStatus("Opened a new tab.");
+    callCallback && callCallback();
+    return true;
+  }
+
+  if (phrase === "open google") {
+    window.open(DOMAIN_MAPPINGS["google"], "_blank");
+    updateStatus && updateStatus("Opened Google in new tab.");
+    callCallback && callCallback();
+    return true;
+  }
+
+  const goToMatch = phrase.match(/^go to (.+)$/);
+  if (goToMatch) {
+    const site = goToMatch[1];
+    const url = getUrlFromSite(site);
+    window.open(url, "_blank");
+    updateStatus && updateStatus(`Opened ${site} in new tab.`);
+    callCallback && callCallback();
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR implements the "Open New Tab with Voice" feature as described in [issue #2](https://github.com/VoiceUI-js/JSVoice/issues/2).

### Features
- Added `OpenTabAction.js` under `src/modules/actions/`
- Supports phrases:
    - “open new tab”
    - “open google”
    - “go to <site>”
- Maps common domains (google, github, youtube, facebook, twitter,Linkedin,ChatGPT) to their respective URLs.
- Opens the requested site using `window.open(url, "_blank")`.
- Registers the new action in `handleBuiltInActions` in `BuiltInActions.js`.

### Usage
- Say “open new tab” to open a blank tab.
- Say “open google” or “go to <site>” to open that site in a new tab.